### PR TITLE
FIX: Fix bug preventing parsing scalar `Expr` as symbolic

### DIFF
--- a/src/pycalphad_xml/parser.py
+++ b/src/pycalphad_xml/parser.py
@@ -181,6 +181,7 @@ def parse_model(dbf, phase_name, model_node, parameters):
             constituent_array = [[str(c) for c in sorted(lx)] for lx in constituent_array]
 
         # Parameter value
+        # Interval _and_ text (if any) to be able to handle intervals or scalar expressions
         param_nodes = param_node.xpath('./Interval') + [''.join(param_node.xpath('./text()')).strip()]
         function_obj = convert_math_to_symbolic(param_nodes)
 
@@ -253,7 +254,9 @@ def read_xml(dbf, fd):
             dbf.species.add(v.Species(species, constituent_dict, charge=species_charge))
         elif child.tag == 'Expr':
             function_name = str(child.attrib['id'])
-            function_obj = convert_intervals_to_piecewise(child)
+            # Interval _and_ text (if any) to be able to handle intervals or scalar expressions
+            expr_nodes = child.xpath('./Interval') + [''.join(child.xpath('./text()')).strip()]
+            function_obj = convert_math_to_symbolic(expr_nodes)
             _setitem_raise_duplicates(dbf.symbols, function_name, function_obj)
         elif child.tag == 'Phase':
             model_nodes = child.xpath('./Model')

--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -94,3 +94,18 @@ def test_xml_roundrip_MQMQA_SUBQ_Q_mixing(load_database):
     print(mod.GM.subs(subs_dict))
     check_energy(mod, subs_dict, -131831.0, mode="sympy")  # FactSage energy, from Max
 
+
+def test_exprs_without_intervals_are_read():
+    XML_STR = """<?xml version="1.0"?>
+    <?xml-model href="database.rng" schematypens="http://relaxng.org/ns/structure/1.0" type="application/xml"?>
+    <Database version="0">
+      <ChemicalElement id="H" mass="1.0" reference_phase="GAS" H298="0.0" S298="0.0"/>
+      <Expr id="VV0000"><Interval in="T" lower="1.0" upper="6000.0">10000</Interval></Expr>
+      <Expr id="VV0001">10000</Expr>
+      <Phase id="F(S)"><Model type="CEF"><ConstituentArray><Site id="0" ratio="1.0"><Constituent refid="H"/></Site></ConstituentArray></Model></Phase>
+    </Database>
+    """
+    db = Database.from_string(XML_STR, fmt="xml")
+
+    assert db.symbols["VV0000"].args[0] == 10000.0
+    assert db.symbols["VV0001"] == 10000.0

--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -94,12 +94,3 @@ def test_xml_roundrip_MQMQA_SUBQ_Q_mixing(load_database):
     print(mod.GM.subs(subs_dict))
     check_energy(mod, subs_dict, -131831.0, mode="sympy")  # FactSage energy, from Max
 
-if __name__ == "__main__":
-    from importlib_resources import files
-    from pycalphad.tests import databases
-    dbf = Database(str(files(databases) / "Shishin_Fe-Sb-O-S_slag.dat"))
-    print(dbf.phases["SLAG-LIQ"])
-    mod = Model(dbf, ['FE', 'O', 'VA'], 'SLAG-LIQ')
-    res = calculate(dbf, ['FE', 'O', 'VA'], 'SLAG-LIQ', T=600, P=1e5)
-    print(res)
-    dbf.to_file('Shishin_MQMQA.xml', if_exists="overwrite")


### PR DESCRIPTION
Before this fix, a scalar `<Expr id="VV0001">10000</Expr>` was getting parsed into a zero because the parser was using `convert_intervals_to_piecewise` instead of `convert_math_to_symbolic`. Includes a test that verifies the intended behavior works correctly for scalar and interval expressions.